### PR TITLE
Update requirements.txt

### DIFF
--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.17
+Django==3.2.18
 pytz==2020.1
 whitenoise==5.2.0
 gunicorn==20.1.0


### PR DESCRIPTION
Version bump for Vulnerabilities
CVE-2023-24580 Low severity
(requirements.txt not used in build, exists for custom builds only)